### PR TITLE
fix consumer cancelling

### DIFF
--- a/lib/ecto_backfiller.ex
+++ b/lib/ecto_backfiller.ex
@@ -164,6 +164,7 @@ defmodule EctoBackfiller do
         end)
         |> Enum.each(fn {consumer, subscription} ->
           :ok = GenStage.cancel({producer, subscription}, :shutdown)
+          Producer.cancel_subscription(producer, consumer)
         end)
       end
 

--- a/lib/ecto_backfiller/producer.ex
+++ b/lib/ecto_backfiller/producer.ex
@@ -27,6 +27,10 @@ defmodule EctoBackfiller.Producer do
     GenStage.cast(producer, {:put_subscription, consumer, subscription})
   end
 
+  def cancel_subscription(producer, consumer) when is_pid(producer) and is_pid(consumer) do
+    GenStage.cast(producer, {:cancel_subscription, consumer})
+  end
+
   # Callbacks
 
   @impl true
@@ -71,6 +75,17 @@ defmodule EctoBackfiller.Producer do
     consumers =
       Enum.map(state.consumers, fn
         {^consumer, _} -> {consumer, subscription}
+        other -> other
+      end)
+
+    {:noreply, [], %{state | consumers: consumers}}
+  end
+
+  @impl true
+  def handle_cast({:cancel_subscription, consumer}, state) do
+    consumers =
+      Enum.map(state.consumers, fn
+        {^consumer, _} -> {consumer, nil}
         other -> other
       end)
 


### PR DESCRIPTION
Closes #1 

Changed the `stop/0` function name to `cancel/0` to follow same the pattern of GenStage API.