### PR TITLE
fix: remove default order by

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ end
 
 ## Documentation
 
-Documentation can be found at [hexdocs](https://hexdocs.pm/ecto_backfiller).
+Documentation on how to use the library and important warnings can be found at [hexdocs](https://hexdocs.pm/ecto_backfiller).
 
 An example application is also available on the repository to
 help you visualize the usage of this library.

--- a/lib/ecto_backfiller.ex
+++ b/lib/ecto_backfiller.ex
@@ -53,6 +53,12 @@ defmodule EctoBackfiller do
   end
   ```
 
+  Please mind that the `handle_batch/1` callback MUST not modify the results of the query, as it
+  will be used to determine the offset for the next batch of data to be fetched.
+
+  You also need to guarantee the ordering of the data fetched, since the backfill is based on
+  offsets, if the data is not ordered, you may end up with duplicated or missing data.
+
   Now you are ready to start executing it and to do so you must start the Supervisor, which will
   be named as the backfill module's name, or in other words, it is a unique proccess per backfill
   module.

--- a/lib/ecto_backfiller/producer.ex
+++ b/lib/ecto_backfiller/producer.ex
@@ -46,7 +46,6 @@ defmodule EctoBackfiller.Producer do
       when demand > 0 do
     events =
       query
-      |> order_by(asc: :inserted_at)
       |> limit(^step)
       |> offset(^offset)
       |> repo.all()


### PR DESCRIPTION
Schemas that use another field for the creation timestamp were crashing.

Also, you may want to order the schema with other keys than the creation timestamp, the library should not set it.