### PR TITLE
chore: producer logs

### DIFF
--- a/lib/ecto_backfiller/producer.ex
+++ b/lib/ecto_backfiller/producer.ex
@@ -1,6 +1,7 @@
 defmodule EctoBackfiller.Producer do
   use GenStage
   import Ecto.Query, only: [limit: 2, offset: 2, order_by: 2]
+  require Logger
 
   defstruct [:query, :step, :offset, :repo, :consumers]
 
@@ -44,11 +45,15 @@ defmodule EctoBackfiller.Producer do
         %__MODULE__{query: query, step: step, offset: offset, repo: repo} = state
       )
       when demand > 0 do
+    Logger.info("Producing #{step} events from #{offset} offset...")
+
     events =
       query
       |> limit(^step)
       |> offset(^offset)
       |> repo.all()
+
+    Logger.info("Produced #{length(events)} events from #{offset} offset")
 
     {:noreply, events, %{state | offset: offset + step}}
   end

--- a/lib/ecto_backfiller/producer.ex
+++ b/lib/ecto_backfiller/producer.ex
@@ -1,6 +1,6 @@
 defmodule EctoBackfiller.Producer do
   use GenStage
-  import Ecto.Query, only: [limit: 2, offset: 2, order_by: 2]
+  import Ecto.Query, only: [limit: 2, offset: 2]
   require Logger
 
   defstruct [:query, :step, :offset, :repo, :consumers]


### PR DESCRIPTION
Add offset logs to ensure the lib user don't lose it if a crash happens during the backfill