### PR TITLE
fix: infinite timeout

### DIFF
--- a/lib/ecto_backfiller/producer.ex
+++ b/lib/ecto_backfiller/producer.ex
@@ -51,7 +51,7 @@ defmodule EctoBackfiller.Producer do
       query
       |> limit(^step)
       |> offset(^offset)
-      |> repo.all()
+      |> repo.all(timeout: :infinity)
 
     Logger.info("Produced #{length(events)} events from #{offset} offset")
 


### PR DESCRIPTION
Since this library uses limit+offset, on longer offsets the query takes longes. Because of that, we are removing the default 15_000ms from Ecto